### PR TITLE
Giving execution permission to the start.sh file through the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,4 +90,4 @@ WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 RUN npm install
 
-CMD /usr/src/app/start.sh
+CMD ["/usr/src/app/start.sh", "chmod", "+x"]


### PR DESCRIPTION
We changed the execution permissions of the start.sh file from the dockerfile, because otherwise the building process raises a "permissions denied" error.