### PR TITLE
Execution error of start.sh during the building process using Dockerfile

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 cd /usr/src/app
 
 if [ "$DEVELOPMENT" == "true" ]


### PR DESCRIPTION
During the building process of the repository, it raised the following error:
exec /usr/src/app/start.sh: exec format error
It was fixed adding the line: #!/bin/bash as the first line in start.sh file.