### PR TITLE
OpenPointClass integration as a command line tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ vdatum/**/*
 tmp/
 static/download/
 static/mapstore/
+static/models/*
+static/class_data/*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,6 @@ services:
     env_file:
       - .env
   openpointclass:
-    # image: uav4geo/openpointclass:latest
     build: https://github.com/uav4geo/OpenPointClass.git
     stdin_open: true # docker run -i
     tty: true        # docker run -t

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,5 +34,17 @@ services:
       - node_network
     env_file:
       - .env
+  openpointclass:
+    # image: uav4geo/openpointclass:latest
+    build: https://github.com/uav4geo/OpenPointClass.git
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    container_name: digital_twin_openpointclass
+    volumes:
+      - ./static:/data/dataset-path
+    networks:
+      - node_network
+    env_file:
+      - .env
 networks:
   node_network:


### PR DESCRIPTION
## Digital Twin Toolbox classifier

Digital Twin Toolbox classifier is a tool for point cloud classification which is based on the [OpenPointClass](https://github.com/uav4geo/OpenPointClass), a C++ implementation for the machine learning algorithms of Random Forest and Gradient Boosted trees. The user is able train the classifier with point clouds that have been labeled and classify new point clouds using the trained model. The recommended format of the point clouds is the LAS / LAZ.

The encoding of the classes follows the [ASPRS 1.4 standard](https://www.asprs.org/wp-content/uploads/2019/03/LAS_1_4_r14.pdf) while the following classses are supported:

Class | code
--- | ---
Unclassified | 1
ground | 2
low_vegetation | 3
medium_vegetation | 4
high_vegetation | 5
building | 6
low_point | 7
water | 9
rail | 10
road_surface | 11
wire_guard | 13
wire_conductor | 14
transmission_tower | 15
wire_structure_connector | 16
bridge_deck | 17
high_noise | 18
overhead_structure | 19
ignored_ground | 20
snow | 21
temporal_exclusion | 22
human_made_object | 64

However, the user is able to re-map the classification encoding, by creating a <FILE>.json in the directory that the dataset is stored:

```bash
{
    "source": "https://url-to-your-data",
    "classification": {
        "0": "ground",
        "1": "building",
        "2": "low_vegetation",
        "3": "medium_vegetation",
        "4": "high_vegetation"
    }
}
```

## Preparation of the classifier's environment
After the installation and setup of the Digital Twin Toolbox through the "docker compose up" command, all the containers should be up and running. To check that the containers are up and running, type the following command:

```bash
docker container ls
```

In the exported list of the active containers, the container: digital_twin_openpointclass should be activated. If not, navigate to the Digital Twin Toolbox repository:

```bash
cd path/to/digital-twin-toolbox
```

and run the the following command:

```bash
docker compose up
```

Afterwards, enter to the bash of the classifier's container:

```bash
docker exec -it digital_twin_openpointclass bash
```

The prompt should be changed to: 

```bash
root@<CONTAINER_ID>:/build#
```

## Usage
From this prompt, the user is able to use the classifier's command line in order to train, classify and evaluate a model.
At first, create two sub-folders in the ./static folder: one for the storage of the models, let's call it "models" and one for the storage of the point clouds, let's call it "class_data". Subsequently, add the desired point clouds (in LAS / LAZ format) to the folder "class_data". There are two main functionalities of the classifier:

-- Model generation through the training process

-- Point cloud classification using a model

## Model generation
At first, store the point cloud(s) that will be used in the training process in the "class_data" folder. Be aware that the point cloud(s) has to be already classified in order the classification values to be used by the classifier as ground truth. Use an external software (CloudCompare is recommended) in order to check if the point clouds are classified and which classes have been labeled.

To train a model using Random Forest algorithm in order to recognize the classes: ground, high vegetation and buildings, execute the following command:

```bash
./pctrain /data/dataset-path/class_data/<input>.laz --output /data/dataset-path/models/<model_name>.bin --classes 2,3,6
```

The user is able to parameterize the training process accordigly, using the following parameters:

Parameter | Description
--- | ---
-r, --resolution | Resolution of the first scale
-s, --scales | Number of scales"
-, --trees | Number of trees in the Random Forest
-d, --depth | Maximum depth of trees
-m, --max-samples | Maximum number of samples for each input point cloud
--radius | Radius size to use for neighbor search (meters)

For instance, to train the same model as above with --trees 20 and depth 15, execute the following:

```bash
./pctrain /data/dataset-path/class_data/<input>.laz --output /data/dataset-path/models/<model_name>.bin --trees 20 --depth 15 --classes 2,3,6
```

After the training process, the model is stored in the ./static/models folder.

## Point cloud classification
The user is able to classify a point cloud classification, either using the [model.bin](https://objects.githubusercontent.com/github-production-release-asset-2e65be/600799581/550d71e4-89df-46f1-8f82-f4de96685af4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240607%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240607T101623Z&X-Amz-Expires=300&X-Amz-Signature=9dca0be3620428ac6fddb80e14dba7a14b52be38e00468352eccdef57b27431e&X-Amz-SignedHeaders=host&actor_id=5483452&key_id=0&repo_id=600799581&response-content-disposition=attachment%3B%20filename%3Dvehicles-vegetation-buildings.zip&response-content-type=application%2Foctet-stream) provided by the develpers of OpenPointClass, or a model trained using the command above.

To classify a point cloud, at first, store the desired point cloud in the "class_data" folder and the model that will be used in the "models" folder. Then, run:

```bash
./pcclassify /data/dataset-path/class_data/<input_name>.laz /data/dataset-path/class_data/<output_name>.laz /data/dataset-path/models/<model_name>.bin
```

It is possible to colorize the main values of the extracted point cloud by using the --color parameter:

```bash
./pcclassify /data/dataset-path/class_data/<input_name>.laz /data/dataset-path/class_data/<output_name>.laz /data/dataset-path/models/<model_name>.bin --color
```
After the execution of the commands above, the exported point cloud is stored in the "class_data" folder.

During the classification process, the user is able to evaluate the model extracting well-known metrics including "Accuracy", "Recall", "Precision" and "F1 score". It's worth noting, that the input point cloud should be already classified in order to be compared with the classifier's output.

```bash
./pcclassify /data/dataset-path/class_data/<input_name>.laz /data/dataset-path/class_data/<output_name>.laz /data/dataset-path/models/<model_name>.bin --eval
```