### PR TITLE
Fix max call stack error

### DIFF
--- a/frontend/src/components/Viewer/PointCloudCanvas.tsx
+++ b/frontend/src/components/Viewer/PointCloudCanvas.tsx
@@ -99,7 +99,7 @@ function PointCloudCanvas({
       const mesh: any = group.children[i]
       mesh.geometry.dispose()
     }
-    group.remove(...group.children)
+    group.children.forEach((e: any) => group.remove(e))
     // @ts-ignore
     const textArr = text.split(/\n/)
     const [, ...rows] = textArr

--- a/frontend/src/components/Viewer/PointGeometryCanvas.tsx
+++ b/frontend/src/components/Viewer/PointGeometryCanvas.tsx
@@ -137,7 +137,7 @@ function PointGeometryCanvas({
       const mesh: any = group.children[i]
       mesh.geometry.dispose()
     }
-    group.remove(...group.children)
+    group.children.forEach((child: any) => group.remove(child))
     // @ts-ignore collection is currently a simple object in the response
     const [minx, miny, maxx, maxy] = turfBbox(collection)
     const center = [minx + (maxx - minx) / 2, miny + (maxy - miny) / 2, 0]

--- a/frontend/src/components/Viewer/PolygonGeometryCanvas.tsx
+++ b/frontend/src/components/Viewer/PolygonGeometryCanvas.tsx
@@ -59,7 +59,7 @@ function PolygonGeometryCanvas({
       const mesh: any = group.children[i]
       mesh.geometry.dispose()
     }
-    group.remove(...group.children)
+    group.children.forEach((child: any) => group.remove(child))
     //@ts-ignore
     const [minx, miny, maxx, maxy] = turfBbox(collection)
     const center = [minx + (maxx - minx) / 2, miny + (maxy - miny) / 2, 0]

--- a/frontend/src/components/Viewer/ThreeCanvas.tsx
+++ b/frontend/src/components/Viewer/ThreeCanvas.tsx
@@ -72,7 +72,7 @@ function ThreeCanvas({ onMount }: ThreeCanvasProps) {
         const mesh: any = group.children[i]
         mesh.geometry.dispose()
       }
-      group.remove(...group.children)
+      group.children.forEach((child: any) => group.remove(child))
       renderer.dispose()
     }
   }, [])


### PR DESCRIPTION
When we have thousands of groups of meshes the `Group.remove()` method receives a too long list of arguments that cause a `Max call stack` error