### PR TITLE
Fix #56 Allow to use full resolutions images in texture reconstruction.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -84,7 +84,9 @@ COPY ./tests-start.sh /app/
 COPY ./app /app/app
 
 RUN mv /app/celery-reload.sh /celery-reload.sh && \
-    mv /app/celery.sh /celery.sh
+    mv /app/celery.sh /celery.sh && \
+    chmod +x /celery-reload.sh && \
+    chmod +x /celery.sh
 
 # Install node
 ARG NODE_VERSION=20.11.1

--- a/backend/app/worker/photogrammetry/images_to_sparse_reconstruction.py
+++ b/backend/app/worker/photogrammetry/images_to_sparse_reconstruction.py
@@ -1,0 +1,122 @@
+
+import logging
+import os
+import json
+import time
+import shutil
+import numpy as np
+import app.worker.photogrammetry.mask_images as mask_images
+from app.worker.photogrammetry.utils import (
+    get_OpenSfM_bin, remove_if_exists, memory_available,
+    create_config_for_stage, run_step, calculate_resource_allocation
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def run(process_dir, config):
+    start = time.time()
+    logger.info("Start OpenSfM process")
+    force_delete = config.get('force_delete', False)
+    auto_resolutions_computation = config.get('auto_resolutions_computation', True)
+    create_statisitcs = config.get('create_statisitcs', False)
+
+    if  force_delete:
+        logger.info("Starting fresh run - cleaning directory")
+        for f in os.listdir(process_dir):
+            if f != 'images':
+                f_path = os.path.join(process_dir, f)
+                if os.path.isfile(f_path):
+                    os.remove(f_path)
+                elif os.path.isdir(f_path):
+                    shutil.rmtree(f_path)
+    else:
+        logger.info("Resuming from previous run based on profile.log")
+
+    images_dir = os.path.join(process_dir, 'images')
+
+    resources = {
+        "processes": int(config.get('processes')),
+        "read_processes": int(config.get('read_processes')),
+        "feature_process_size": int(config.get('feature_process_size')),
+        "memory_mb": memory_available()
+    }
+
+    if auto_resolutions_computation:
+        resources = calculate_resource_allocation(images_dir)
+
+    logger.info(f"Resource allocation: {resources['processes']} processes, "
+                f"{resources['feature_process_size']} feature process size")
+
+    config_yaml = {
+        'processes': resources['processes'],
+        'read_processes': resources['read_processes'],
+        'feature_type': 'SIFT',
+        'feature_process_size': resources['feature_process_size'],
+        'feature_min_frames': 30000,
+        'sift_peak_threshold': 0.066,
+        'matcher_type': 'FLANN',
+        'flann_algorithm': 'KDTREE',
+        'matching_gps_neighbors': 0,
+        'matching_gps_distance': 0,
+        'matching_graph_rounds': 50,
+        'triangulation_type': 'ROBUST',
+        'use_exif_size': 'no',
+        'use_altitude_tag': 'yes',
+        'optimize_camera_parameters': 'yes',
+        'bundle_outlier_filtering_type': 'AUTO',
+        'align_method': 'auto',
+        'align_orientation_prior': 'vertical',
+        'local_bundle_radius': 0,
+        'bundle_use_gcp': 'no',
+        'retriangulation_ratio': 2,
+        'undistorted_image_format': 'jpg',
+    }
+
+    create_config_for_stage(process_dir, config_yaml)
+
+    original_camera_models_overrides = os.path.join(images_dir, 'camera_models_overrides.json')
+    camera_models_overrides = os.path.join(process_dir, 'camera_models_overrides.json')
+    original_exif_overrides = os.path.join(images_dir, 'exif_overrides.json')
+    exif_overrides = os.path.join(process_dir, 'exif_overrides.json')
+    if os.path.exists(original_camera_models_overrides):
+        shutil.copyfile(original_camera_models_overrides, camera_models_overrides)
+    if os.path.exists(original_exif_overrides):
+        shutil.copyfile(original_exif_overrides, exif_overrides)
+
+    cmd = get_OpenSfM_bin()
+
+    if run_step('extract_metadata', cmd + ['extract_metadata', process_dir], process_dir):
+        remove_if_exists(camera_models_overrides)
+        remove_if_exists(exif_overrides)
+
+    run_step('detect_features', cmd + ['detect_features', process_dir], process_dir)
+    run_step('match_features', cmd + ['match_features', process_dir], process_dir)
+    run_step('create_tracks', cmd + ['create_tracks', process_dir], process_dir)
+    run_step('reconstruct', cmd + ['reconstruct', '--algorithm', 'triangulation', process_dir], process_dir)
+
+
+    # optional
+    if create_statisitcs:
+        run_step('compute_statistics', cmd + ['compute_statistics', process_dir], process_dir)
+        run_step('export_report', cmd + ['export_report', process_dir], process_dir)
+        run_step('export_ply', cmd + ['export_ply', process_dir], process_dir)
+    # end -- optional
+
+    reconstruction = None
+    reconstruction_path = os.path.join(process_dir, 'reconstruction.json')
+    if os.path.exists(reconstruction_path):
+        with open(reconstruction_path, 'r') as f:
+            reconstruction = json.load(f)
+
+        cameras_path = os.path.join(process_dir, 'camera_models.json')
+        remove_if_exists(cameras_path)
+
+        cameras = reconstruction[0].get('cameras')
+        with open(cameras_path, 'w') as f:
+            json.dump(cameras, f, indent=4)
+
+    end = time.time()
+    elapsed_time = end - start
+    logger.info(f"End of sparse reconstruction process in {elapsed_time} seconds")

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -10,6 +10,7 @@ import subprocess
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
+from app.worker.photogrammetry.images_to_point_cloud import run_step, create_config_for_stage, get_OpenSfM_bin
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -436,6 +437,18 @@ def create_texture(params):
     """Create textured mesh"""
 
     process_dir = params.get('process_dir')
+
+    depthmap_resolution = params.get('depthmap_resolution')
+    texture_image_resolution = params.get('texture_image_resolution')
+    if depthmap_resolution != texture_image_resolution:
+        config_yaml = {
+            'undistorted_image_max_size': texture_image_resolution
+        }
+        cmd = get_OpenSfM_bin()
+        create_config_for_stage(process_dir, config_yaml)
+        run_step('undistort', cmd + ['undistort', process_dir], process_dir)
+        run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
+    
     output_textured_dir = params.get('output_textured_dir')
     output_textured_dir_zip = params.get('output_textured_dir_zip')
     output_ply = params.get('output_ply')
@@ -490,6 +503,9 @@ def run(process_dir, config):
         logger.info("Resuming from previous run based on existing outputs")
 
     point_cloud_process_max_workers = 16
+
+    depthmap_resolution = config.get("depthmap_resolution", 1024)
+    texture_image_resolution = config.get('texture_image_resolution', 4096)
     params = {
         **config,
         'process_dir': process_dir,
@@ -498,7 +514,9 @@ def run(process_dir, config):
         'output_ply': output_ply,
         'output_textured_dir': output_textured_dir,
         'output_textured_dir_zip': output_textured_dir_zip,
-        'point_cloud_process_max_workers': point_cloud_process_max_workers
+        'point_cloud_process_max_workers': point_cloud_process_max_workers,
+        'depthmap_resolution': depthmap_resolution,
+        'texture_image_resolution': texture_image_resolution
     }
 
     if force_delete or not os.path.exists(output_xyz):

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -10,7 +10,9 @@ import subprocess
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
-from app.worker.photogrammetry.images_to_point_cloud import run_step, create_config_for_stage, get_OpenSfM_bin
+from app.worker.photogrammetry.utils import (
+    get_OpenSfM_bin, run_step, create_config_for_stage
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -21,7 +23,7 @@ WGS84_a = 6378137.0
 WGS84_b = 6356752.314245
 
 # from opensfm
-def ecef_from_lla(lat, lon, alt):
+def ecef_from_lla(lat, lon, alt):                          
     """
     Compute ECEF XYZ from latitude, longitude and altitude.
 
@@ -440,15 +442,22 @@ def create_texture(params):
 
     depthmap_resolution = params.get('depthmap_resolution')
     texture_image_resolution = params.get('texture_image_resolution')
+    texture_image_processes = params.get('texture_image_processes', 1)
     if depthmap_resolution != texture_image_resolution:
         config_yaml = {
-            'undistorted_image_max_size': texture_image_resolution
+            'undistorted_image_max_size': texture_image_resolution,
+            'undistorted_image_format': 'jpg',
+            'processes': texture_image_processes,
+            'read_processes': texture_image_processes,
         }
         cmd = get_OpenSfM_bin()
         create_config_for_stage(process_dir, config_yaml)
-        run_step('undistort', cmd + ['undistort', process_dir], process_dir)
-        run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
+        undistorted_images_dir = os.path.join(process_dir, 'undistorted', 'images')
+        if os.path.exists(undistorted_images_dir):
+            shutil.rmtree(undistorted_images_dir)
+        run_step('undistort', cmd + ['undistort', process_dir], process_dir, skip_check=True)
     
+    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
     output_textured_dir = params.get('output_textured_dir')
     output_textured_dir_zip = params.get('output_textured_dir_zip')
     output_ply = params.get('output_ply')
@@ -506,6 +515,7 @@ def run(process_dir, config):
 
     depthmap_resolution = config.get("depthmap_resolution", 1024)
     texture_image_resolution = config.get('texture_image_resolution', 4096)
+    texture_image_processes = config.get('texture_image_processes', 1)
     params = {
         **config,
         'process_dir': process_dir,
@@ -516,7 +526,8 @@ def run(process_dir, config):
         'output_textured_dir_zip': output_textured_dir_zip,
         'point_cloud_process_max_workers': point_cloud_process_max_workers,
         'depthmap_resolution': depthmap_resolution,
-        'texture_image_resolution': texture_image_resolution
+        'texture_image_resolution': texture_image_resolution,
+        'texture_image_processes': texture_image_processes
     }
 
     if force_delete or not os.path.exists(output_xyz):

--- a/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
+++ b/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
@@ -1,61 +1,200 @@
 import logging
+import subprocess
 import os
 import json
-import time
+import sys
+import psutil
 import numpy as np
 import open3d as o3d
-import app.worker.photogrammetry.mask_images as mask_images
-from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
-from app.worker.photogrammetry.utils import (
-    get_OpenSfM_bin, run_step, create_config_for_stage,
-    calculate_depthmap_resources, crop_dense_point_cloud
-)
+import cv2
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def run(process_dir, config):
-    start = time.time()
-    logger.info("Start dense point cloud reconstruction process")
+def get_OpenSfM_bin():
+    """Returns the command to run OpenSfM binaries"""
+    return ['micromamba', 'run', '-n', 'opensfm', '/source/OpenSfM/bin/opensfm']
 
-    auto_resolutions_computation = config.get('auto_resolutions_computation', True)
-    
-    reconstruction_path = os.path.join(process_dir, 'reconstruction.json')
-    if not os.path.exists(reconstruction_path):
-        logger.error("Sparse reconstruction not found. Run images_to_sparse_reconstruction first.")
-        return False
-    
-    mask_images.run(process_dir)
+def remove_if_exists(path):
+    """Remove file if it exists"""
+    if os.path.exists(path):
+        os.remove(path)
 
-    depthmap_resolution = config.get("depthmap_resolution", 1024)
-    depthmap_processes = config.get("depthmap_processes", 1)
+def memory_available() -> int:
+    """Returns available memory in MB"""
+    if sys.platform == "win32":
+        # Windows implementation
+        import ctypes
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+            def __init__(self) -> None:
+                self.dwLength = ctypes.sizeof(self)
+                super(MEMORYSTATUSEX, self).__init__()
+        
+        stat = MEMORYSTATUSEX()
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+        return int(stat.ullAvailPhys / 1024 / 1024)
+    else:
+        # Linux/macOS implementation
+        with os.popen("free -t -m") as fp:
+            lines = fp.readlines()
+        if not lines:
+            return int(psutil.virtual_memory().available / 1024 / 1024)
+        available_mem = int(lines[1].split()[6])
+        return available_mem
 
-    if auto_resolutions_computation:
-        resources = calculate_depthmap_resources()
-        depthmap_processes = resources["depthmap_processes"]
-        depthmap_resolution = resources["depthmap_resolution"]
+def get_cpu_count() -> int:
+    """Returns the number of available CPU cores"""
+    return psutil.cpu_count(logical=False) or 1
+
+def get_max_image_resolution(images_dir: str):
+    """Get the maximum resolution of images in the directory"""
+    max_width, max_height = 0, 0
+    try:
+        for filename in os.listdir(images_dir):
+            if filename.lower().endswith(('.jpg', '.jpeg', '.png', '.tif', '.tiff')):
+                img_path = os.path.join(images_dir, filename)
+                img = cv2.imread(img_path)
+                if img is not None:
+                    height, width = img.shape[:2]
+                    max_width = max(max_width, width)
+                    max_height = max(max_height, height)
+    except Exception as e:
+        logger.warning(f"Error reading image dimensions: {e}")
+        return (1920, 1080)
     
-    config_yaml = {
-        'processes': depthmap_processes,
-        'read_processes': depthmap_processes,
-        'depthmap_min_consistent_views': 3,
-        'depthmap_resolution': depthmap_resolution,
-        'undistorted_image_format': 'jpg',
-        'undistorted_image_max_size': int(config.get('texture_image_resolution', 4096))
+    if max_width == 0 or max_height == 0:
+        return (1920, 1080)
+    
+    return (max_width, max_height)
+
+def calculate_resource_allocation(images_dir: str):
+    """Calculate optimal resource allocation based on system capabilities and image resolution"""
+    available_memory_mb = memory_available()
+    cpu_count = get_cpu_count()
+    max_width, max_height = get_max_image_resolution(images_dir)
+    max_mp = (max_width * max_height) / 1_000_000  # Megapixels
+    
+    logger.info(f"System has {cpu_count} CPU cores and {available_memory_mb}MB available memory")
+    logger.info(f"Maximum image resolution: {max_width}x{max_height} ({max_mp:.2f}MP)")
+
+    processes = max(1, min(cpu_count - 1, 8)) 
+    depthmap_processes = max(1, processes // 2)  
+    
+    smallest_dimension = min(max_width, max_height)
+    
+    if max_mp > 20:       # Very large images
+        scale_factor = 0.4
+    elif max_mp > 10:     # Large images
+        scale_factor = 0.6
+    else:                 # Medium/small images
+        scale_factor = 0.8
+    
+    if available_memory_mb < 4000:
+        scale_factor *= 0.7
+    
+    feature_process_size = int(smallest_dimension * scale_factor)
+    feature_process_size = max(1024, min(smallest_dimension, min(4096, feature_process_size)))
+    feature_process_size = (feature_process_size // 16) * 16  
+    
+    depthmap_resolution = min(smallest_dimension, max(1024, int(feature_process_size * 1.2)))
+    depthmap_resolution = (depthmap_resolution // 16) * 16  
+    
+    logger.info(f"Allocated resources: {processes} processes ({depthmap_processes} for depth maps)")
+    logger.info(f"Feature process size: {feature_process_size}px (original image: {max_width}x{max_height})")
+    logger.info(f"Depth map resolution: {depthmap_resolution}px (original image: {max_width}x{max_height})")
+    
+    return {
+        "processes": processes,
+        "read_processes": processes,
+        "depthmap_resolution": depthmap_resolution,
+        "depthmap_processes": depthmap_processes,
+        "feature_process_size": feature_process_size,
+        "memory_mb": available_memory_mb
     }
-    
-    create_config_for_stage(process_dir, config_yaml)
-    
-    cmd = get_OpenSfM_bin()
-    
 
-    run_step('undistort', cmd + ['undistort', process_dir], process_dir)
-    run_step('compute_depthmaps', cmd + ['compute_depthmaps', process_dir], process_dir)
-    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
+def calculate_depthmap_resources():
+    """Calculate optimal resource allocation for depth map computation"""
+    available_memory_mb = memory_available()
+    cpu_count = get_cpu_count()
     
-    crop_dense_point_cloud({'process_dir': process_dir})
+    depthmap_processes = max(1, min(cpu_count // 2, 4))
+    depthmap_resolution = 2048  # Default resolution
     
-    end = time.time()
-    elapsed_time = end - start
-    logger.info(f"End of dense point cloud reconstruction process in {elapsed_time} seconds")
-    return True
+    if available_memory_mb < 4000:
+        depthmap_processes = max(1, depthmap_processes - 1)
+        depthmap_resolution = 1536
+    elif available_memory_mb > 16000:
+        depthmap_resolution = 3072
+    
+    depthmap_resolution = (depthmap_resolution // 16) * 16
+    
+    logger.info(f"Depthmap resource allocation: {depthmap_processes} processes, {depthmap_resolution}px resolution")
+    
+    return {
+        "depthmap_processes": depthmap_processes,
+        "depthmap_resolution": depthmap_resolution
+    }
+
+def create_config_for_stage(process_dir: str, config_yaml: dict):
+    """Update the config.yaml file for a specific pipeline stage"""
+    config_path = os.path.join(process_dir, 'config.yaml')
+    
+    if os.path.exists(config_path):
+        os.remove(config_path)
+
+    config_updates = []
+    for key, value in config_yaml.items():
+        config_updates.append(f'{key}: {value}')
+    with open(config_path, 'w') as f:
+        f.write('\n'.join(config_updates))
+    
+    logger.info(f"Updated configuration for next stage: {config_updates}")
+
+def get_completed_steps(process_dir: str):
+    """Read OpenSfM's profile.log to determine completed steps"""
+    profile_log_path = os.path.join(process_dir, 'profile.log')
+    completed_steps = {}
+    
+    if os.path.exists(profile_log_path):
+        try:
+            with open(profile_log_path, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and ': ' in line:
+                        step, _ = line.split(': ', 1)
+                        completed_steps[step] = True
+            logger.info(f"Found completed steps in profile.log: {list(completed_steps.keys())}")
+        except Exception as e:
+            logger.warning(f"Error reading profile.log: {e}")
+    
+    return completed_steps
+
+def run_step(step_name, command, process_dir: str, skip_check=False):
+    """Run a processing step if it hasn't been completed already"""
+    
+    if not skip_check:
+        completed_steps = get_completed_steps(process_dir)
+        
+        if step_name in completed_steps:
+            logger.info(f"Skipping already completed step: {step_name}")
+            return True
+        
+    logger.info(f"Running step: {step_name}")
+    try:
+        subprocess.run(command, check=True)
+        return True
+    except Exception as e:
+        logger.error(f"Step {step_name} failed: {e}")
+        return False
+

--- a/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
+++ b/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
@@ -1,0 +1,61 @@
+import logging
+import os
+import json
+import time
+import numpy as np
+import open3d as o3d
+import app.worker.photogrammetry.mask_images as mask_images
+from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
+from app.worker.photogrammetry.utils import (
+    get_OpenSfM_bin, run_step, create_config_for_stage,
+    calculate_depthmap_resources, crop_dense_point_cloud
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def run(process_dir, config):
+    start = time.time()
+    logger.info("Start dense point cloud reconstruction process")
+
+    auto_resolutions_computation = config.get('auto_resolutions_computation', True)
+    
+    reconstruction_path = os.path.join(process_dir, 'reconstruction.json')
+    if not os.path.exists(reconstruction_path):
+        logger.error("Sparse reconstruction not found. Run images_to_sparse_reconstruction first.")
+        return False
+    
+    mask_images.run(process_dir)
+
+    depthmap_resolution = config.get("depthmap_resolution", 1024)
+    depthmap_processes = config.get("depthmap_processes", 1)
+
+    if auto_resolutions_computation:
+        resources = calculate_depthmap_resources()
+        depthmap_processes = resources["depthmap_processes"]
+        depthmap_resolution = resources["depthmap_resolution"]
+    
+    config_yaml = {
+        'processes': depthmap_processes,
+        'read_processes': depthmap_processes,
+        'depthmap_min_consistent_views': 3,
+        'depthmap_resolution': depthmap_resolution,
+        'undistorted_image_format': 'jpg',
+        'undistorted_image_max_size': int(config.get('texture_image_resolution', 4096))
+    }
+    
+    create_config_for_stage(process_dir, config_yaml)
+    
+    cmd = get_OpenSfM_bin()
+    
+
+    run_step('undistort', cmd + ['undistort', process_dir], process_dir)
+    run_step('compute_depthmaps', cmd + ['compute_depthmaps', process_dir], process_dir)
+    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
+    
+    crop_dense_point_cloud({'process_dir': process_dir})
+    
+    end = time.time()
+    elapsed_time = end - start
+    logger.info(f"End of dense point cloud reconstruction process in {elapsed_time} seconds")
+    return True

--- a/backend/app/worker/photogrammetry/utils.py
+++ b/backend/app/worker/photogrammetry/utils.py
@@ -181,13 +181,15 @@ def get_completed_steps(process_dir: str):
     
     return completed_steps
 
-def run_step(step_name, command, process_dir: str):
+def run_step(step_name, command, process_dir: str, skip_check=False):
     """Run a processing step if it hasn't been completed already"""
-    completed_steps = get_completed_steps(process_dir)
     
-    if step_name in completed_steps:
-        logger.info(f"Skipping already completed step: {step_name}")
-        return True
+    if not skip_check:
+        completed_steps = get_completed_steps(process_dir)
+        
+        if step_name in completed_steps:
+            logger.info(f"Skipping already completed step: {step_name}")
+            return True
         
     logger.info(f"Running step: {step_name}")
     try:

--- a/backend/app/worker/photogrammetry/utils.py
+++ b/backend/app/worker/photogrammetry/utils.py
@@ -1,25 +1,23 @@
-
 import logging
 import subprocess
 import os
 import json
-import time
-import shutil
 import sys
 import psutil
-import cv2 
 import numpy as np
-from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
 import open3d as o3d
-import app.worker.photogrammetry.mask_images as mask_images
+import cv2
+from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def get_OpenSfM_bin():
+    """Returns the command to run OpenSfM binaries"""
     return ['micromamba', 'run', '-n', 'opensfm', '/source/OpenSfM/bin/opensfm']
 
 def remove_if_exists(path):
+    """Remove file if it exists"""
     if os.path.exists(path):
         os.remove(path)
 
@@ -58,7 +56,7 @@ def memory_available() -> int:
 
 def get_cpu_count() -> int:
     """Returns the number of available CPU cores"""
-    return psutil.cpu_count(logical=False) or 1  
+    return psutil.cpu_count(logical=False) or 1
 
 def get_max_image_resolution(images_dir: str):
     """Get the maximum resolution of images in the directory"""
@@ -126,7 +124,30 @@ def calculate_resource_allocation(images_dir: str):
         "memory_mb": available_memory_mb
     }
 
-def create_config_for_stage(process_dir: str, config_yaml:dict):
+def calculate_depthmap_resources():
+    """Calculate optimal resource allocation for depth map computation"""
+    available_memory_mb = memory_available()
+    cpu_count = get_cpu_count()
+    
+    depthmap_processes = max(1, min(cpu_count // 2, 4))
+    depthmap_resolution = 2048  # Default resolution
+    
+    if available_memory_mb < 4000:
+        depthmap_processes = max(1, depthmap_processes - 1)
+        depthmap_resolution = 1536
+    elif available_memory_mb > 16000:
+        depthmap_resolution = 3072
+    
+    depthmap_resolution = (depthmap_resolution // 16) * 16
+    
+    logger.info(f"Depthmap resource allocation: {depthmap_processes} processes, {depthmap_resolution}px resolution")
+    
+    return {
+        "depthmap_processes": depthmap_processes,
+        "depthmap_resolution": depthmap_resolution
+    }
+
+def create_config_for_stage(process_dir: str, config_yaml: dict):
     """Update the config.yaml file for a specific pipeline stage"""
     config_path = os.path.join(process_dir, 'config.yaml')
     
@@ -140,8 +161,6 @@ def create_config_for_stage(process_dir: str, config_yaml:dict):
         f.write('\n'.join(config_updates))
     
     logger.info(f"Updated configuration for next stage: {config_updates}")
-
-
 
 def get_completed_steps(process_dir: str):
     """Read OpenSfM's profile.log to determine completed steps"""
@@ -163,6 +182,7 @@ def get_completed_steps(process_dir: str):
     return completed_steps
 
 def run_step(step_name, command, process_dir: str):
+    """Run a processing step if it hasn't been completed already"""
     completed_steps = get_completed_steps(process_dir)
     
     if step_name in completed_steps:
@@ -178,7 +198,7 @@ def run_step(step_name, command, process_dir: str):
         return False
 
 def crop_dense_point_cloud(params):
-
+    """Crop a dense point cloud using geographic bounds"""
     process_dir = params.get('process_dir')
 
     reference_lla = None
@@ -205,130 +225,3 @@ def crop_dense_point_cloud(params):
         o3d.io.write_point_cloud(dense_ply, cropped_pcd, write_ascii=True, compressed=False, print_progress=True)
     else:
         logger.info("Skip point cloud cropping")
-
-def run(process_dir, config):
-    start = time.time()
-    logger.info("Start OpenSfM process")
-    force_delete = config.get('force_delete', False)
-    auto_resolutions_computation = config.get('auto_resolutions_computation', True)
-    create_statisitcs = config.get('create_statisitcs', False)
-
-    if  force_delete:
-        logger.info("Starting fresh run - cleaning directory")
-        for f in os.listdir(process_dir):
-            if f != 'images':
-                f_path = os.path.join(process_dir, f)
-                if os.path.isfile(f_path):
-                    os.remove(f_path)
-                elif os.path.isdir(f_path):
-                    shutil.rmtree(f_path)
-    else:
-        logger.info("Resuming from previous run based on profile.log")
-
-    images_dir = os.path.join(process_dir, 'images')
-
-    resources = {
-        "processes": int(config.get('processes')),
-        "read_processes": int(config.get('read_processes')),
-        "depthmap_resolution": int(config.get('depthmap_resolution')),
-        "depthmap_processes": int(config.get('depthmap_processes')),
-        "feature_process_size": int(config.get('feature_process_size')),
-        "memory_mb": memory_available()
-    }
-
-    if auto_resolutions_computation:
-        resources = calculate_resource_allocation(images_dir)
-
-    logger.info(f"Resource allocation: {resources['processes']} processes, "
-                f"{resources['feature_process_size']} feature process size, "
-                f"{resources['depthmap_resolution']} depthmap resolution")
-
-    config_yaml = {
-        'processes': resources['processes'],
-        'read_processes': resources['read_processes'],
-        'feature_type': 'SIFT',
-        'feature_process_size': resources['feature_process_size'],
-        'feature_min_frames': 30000,
-        'sift_peak_threshold': 0.066,
-        'matcher_type': 'FLANN',
-        'flann_algorithm': 'KDTREE',
-        'matching_gps_neighbors': 0,
-        'matching_gps_distance': 0,
-        'matching_graph_rounds': 50,
-        'triangulation_type': 'ROBUST',
-        'use_exif_size': 'no',
-        'use_altitude_tag': 'yes',
-        'optimize_camera_parameters': 'yes',
-        'bundle_outlier_filtering_type': 'AUTO',
-        'align_method': 'auto',
-        'align_orientation_prior': 'vertical',
-        'local_bundle_radius': 0,
-        'bundle_use_gcp': 'no',
-        'retriangulation_ratio': 2,
-        'undistorted_image_format': 'jpg', # tif
-        'undistorted_image_max_size': int(config.get('texture_image_resolution')),
-        'depthmap_min_consistent_views': 3,
-        'depthmap_resolution': resources['depthmap_resolution']
-    }
-
-    create_config_for_stage(process_dir, config_yaml)
-
-    original_camera_models_overrides = os.path.join(images_dir, 'camera_models_overrides.json')
-    camera_models_overrides = os.path.join(process_dir, 'camera_models_overrides.json')
-    original_exif_overrides = os.path.join(images_dir, 'exif_overrides.json')
-    exif_overrides = os.path.join(process_dir, 'exif_overrides.json')
-    if os.path.exists(original_camera_models_overrides):
-        shutil.copyfile(original_camera_models_overrides, camera_models_overrides)
-    if os.path.exists(original_exif_overrides):
-        shutil.copyfile(original_exif_overrides, exif_overrides)
-
-    cmd = get_OpenSfM_bin()
-
-    if run_step('extract_metadata', cmd + ['extract_metadata', process_dir], process_dir):
-        remove_if_exists(camera_models_overrides)
-        remove_if_exists(exif_overrides)
-
-    run_step('detect_features', cmd + ['detect_features', process_dir], process_dir)
-    run_step('match_features', cmd + ['match_features', process_dir], process_dir)
-    run_step('create_tracks', cmd + ['create_tracks', process_dir], process_dir)
-    run_step('reconstruct', cmd + ['reconstruct', '--algorithm', 'triangulation', process_dir], process_dir)
-
-    mask_images.run(process_dir)
-
-    # optional
-    if create_statisitcs:
-        run_step('compute_statistics', cmd + ['compute_statistics', process_dir], process_dir)
-        run_step('export_report', cmd + ['export_report', process_dir], process_dir)
-        run_step('export_ply', cmd + ['export_ply', process_dir], process_dir)
-    # end -- optional
-
-    reconstruction = None
-    reconstruction_path = os.path.join(process_dir, 'reconstruction.json')
-    if os.path.exists(reconstruction_path):
-        with open(reconstruction_path, 'r') as f:
-            reconstruction = json.load(f)
-
-        cameras_path = os.path.join(process_dir, 'camera_models.json')
-        remove_if_exists(cameras_path)
-
-        cameras = reconstruction[0].get('cameras')
-        with open(cameras_path, 'w') as f:
-            json.dump(cameras, f, indent=4)
-
-    create_config_for_stage(process_dir, {
-        **config_yaml,
-        'processes': resources['depthmap_processes'],
-        'read_processes': resources['depthmap_processes']
-    })
-
-    run_step('undistort', cmd + ['undistort', process_dir], process_dir)
-    run_step('compute_depthmaps', cmd + ['compute_depthmaps', process_dir], process_dir)
-    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
-
-    # --- end opensfm
-
-    crop_dense_point_cloud({ 'process_dir': process_dir })
-
-    end = time.time()
-    elapsed_time = end - start
-    logger.info(f"End of OpenSfM process in {elapsed_time} seconds")

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -617,7 +617,8 @@ def create_reconstructed_mesh(pipeline_extended):
         "processes": 1,
         "read_processes": 4,
         "depthmap_processes": 1,
-        'texture_image_resolution': 4096
+        'texture_image_resolution': 4096,
+        'texture_image_processes': 1,
     }
 
     config = {

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -26,7 +26,8 @@ from pyproj import CRS
 import time
 from concurrent.futures import ThreadPoolExecutor
 import zipfile
-import app.worker.photogrammetry.images_to_point_cloud as images_to_point_cloud
+import app.worker.photogrammetry.images_to_sparse_reconstruction as images_to_sparse_reconstruction
+import app.worker.photogrammetry.sparse_reconstruction_to_dense_point_cloud as sparse_reconstruction_to_dense_point_cloud
 import app.worker.photogrammetry.point_cloud_to_mesh as point_cloud_to_mesh
 import app.worker.photogrammetry.mesh_tiling as mesh_tiling
 
@@ -626,11 +627,17 @@ def create_reconstructed_mesh(pipeline_extended):
 
     stage = config.get('stage')
 
-    if stage == 'all' or stage == 'images_to_point_cloud':
+    if stage == 'all' or stage == 'images_to_sparse_reconstruction':
         config_overrides = {
             **config,
         }
-        images_to_point_cloud.run(process_dir, config_overrides)
+        images_to_sparse_reconstruction.run(process_dir, config_overrides)
+    
+    if stage == 'all' or stage == 'sparse_reconstruction_to_dense_point_cloud':
+        config_overrides = {
+            **config,
+        }
+        sparse_reconstruction_to_dense_point_cloud.run(process_dir, config_overrides)
 
     if stage == 'all' or stage == 'point_cloud_to_mesh':
         config_overrides = {

--- a/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
+++ b/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
@@ -126,6 +126,7 @@ function PhotogrammetryCanvas({
     read_processes: 4,
     depthmap_processes: 1,
     texture_image_resolution: 4096,
+    texture_image_processes: 1,
     ...pipeline.data,
   })
 
@@ -399,6 +400,20 @@ function PhotogrammetryCanvas({
               defaultValue={data?.texture_image_resolution}
               onChange={(event) =>
                 handleOnChange("texture_image_resolution", parseInt(event.target.value))
+              }
+            />
+          </FormControl>
+          <FormControl mt={2} mb={2} >
+            <FormLabel fontSize="xs" htmlFor="texture_image_processes">
+              Texture image processes
+            </FormLabel>
+            <Input
+              id="texture_image_processes"
+              size="xs"
+              type="number"
+              defaultValue={data?.texture_image_processes}
+              onChange={(event) =>
+                handleOnChange("texture_image_processes", parseInt(event.target.value))
               }
             />
           </FormControl>

--- a/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
+++ b/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
@@ -299,8 +299,11 @@ function PhotogrammetryCanvas({
               <option value={'all'}>
                 All
               </option>
-              <option value={'images_to_point_cloud'}>
-                Images to point cloud
+              <option value={'images_to_sparse_reconstruction'}>
+                Images to sparse reconstruction
+              </option>
+              <option value={'sparse_reconstruction_to_dense_point_cloud'}>
+                Sparse reconstruction to dense point cloud
               </option>
               <option value={'point_cloud_to_mesh'}>
                 Point cloud to mesh


### PR DESCRIPTION
This PR includes following:

1. Property texture_image_resolution is independent from the depthmap_resolution. 
2. Undistort phase for dense reconstruction use depthmap_resolution
3. When texture_image_resolution is different from depthmap_resolution  a new set of undistorted images is used only for the texture reconstruction process
4. The .nvm file should is re generated in the texture reconstruction phase as soon the undistorted images are ready