### PR TITLE
Fix #56 Allow to use full resolutions images in texture reconstruction

### DIFF
--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -10,6 +10,9 @@ import subprocess
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
+from app.worker.photogrammetry.utils import (
+    get_OpenSfM_bin, run_step, create_config_for_stage
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -436,6 +439,25 @@ def create_texture(params):
     """Create textured mesh"""
 
     process_dir = params.get('process_dir')
+
+    depthmap_resolution = params.get('depthmap_resolution')
+    texture_image_resolution = params.get('texture_image_resolution')
+    texture_image_processes = params.get('texture_image_processes', 1)
+    if depthmap_resolution != texture_image_resolution:
+        config_yaml = {
+            'undistorted_image_max_size': texture_image_resolution,
+            'undistorted_image_format': 'jpg',
+            'processes': texture_image_processes,
+            'read_processes': texture_image_processes,
+        }
+        cmd = get_OpenSfM_bin()
+        create_config_for_stage(process_dir, config_yaml)
+        undistorted_images_dir = os.path.join(process_dir, 'undistorted', 'images')
+        if os.path.exists(undistorted_images_dir):
+            shutil.rmtree(undistorted_images_dir)
+        run_step('undistort', cmd + ['undistort', process_dir], process_dir, skip_check=True)
+    
+    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
     output_textured_dir = params.get('output_textured_dir')
     output_textured_dir_zip = params.get('output_textured_dir_zip')
     output_ply = params.get('output_ply')
@@ -490,6 +512,10 @@ def run(process_dir, config):
         logger.info("Resuming from previous run based on existing outputs")
 
     point_cloud_process_max_workers = 16
+
+    depthmap_resolution = config.get("depthmap_resolution", 1024)
+    texture_image_resolution = config.get('texture_image_resolution', 4096)
+    texture_image_processes = config.get('texture_image_processes', 1)
     params = {
         **config,
         'process_dir': process_dir,
@@ -498,7 +524,10 @@ def run(process_dir, config):
         'output_ply': output_ply,
         'output_textured_dir': output_textured_dir,
         'output_textured_dir_zip': output_textured_dir_zip,
-        'point_cloud_process_max_workers': point_cloud_process_max_workers
+        'point_cloud_process_max_workers': point_cloud_process_max_workers,
+        'depthmap_resolution': depthmap_resolution,
+        'texture_image_resolution': texture_image_resolution,
+        'texture_image_processes': texture_image_processes
     }
 
     if force_delete or not os.path.exists(output_xyz):

--- a/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
+++ b/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
@@ -8,11 +8,41 @@ import app.worker.photogrammetry.mask_images as mask_images
 from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
 from app.worker.photogrammetry.utils import (
     get_OpenSfM_bin, run_step, create_config_for_stage,
-    calculate_depthmap_resources, crop_dense_point_cloud
+    calculate_depthmap_resources
 )
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def crop_dense_point_cloud(params):
+    """Crop a dense point cloud using geographic bounds"""
+    process_dir = params.get('process_dir')
+
+    reference_lla = None
+    reference_lla_path = os.path.join(process_dir, 'reference_lla.json')
+    with open(reference_lla_path, 'r') as f:
+        reference_lla = json.load(f)
+
+    config = None
+    config_path = os.path.join(process_dir, 'images', 'config.json')
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+
+    bbox = transform_extent_to_local(reference_lla, config)
+
+    if bbox:
+        logger.info("Cropping dense point cloud")
+        dense_ply = os.path.join(process_dir, 'undistorted', 'depthmaps', 'merged.ply')
+        pcd = o3d.io.read_point_cloud(dense_ply)
+        min_bound = np.array([bbox[0], bbox[1], float('-inf')])
+        max_bound = np.array([bbox[2], bbox[3], float('inf')])
+        bbox = o3d.geometry.AxisAlignedBoundingBox(min_bound=min_bound, max_bound=max_bound)
+        cropped_pcd = pcd.crop(bbox)
+        o3d.io.write_point_cloud(dense_ply, cropped_pcd, write_ascii=True, compressed=False, print_progress=True)
+    else:
+        logger.info("Skip point cloud cropping")
 
 def run(process_dir, config):
     start = time.time()
@@ -41,7 +71,7 @@ def run(process_dir, config):
         'depthmap_min_consistent_views': 3,
         'depthmap_resolution': depthmap_resolution,
         'undistorted_image_format': 'jpg',
-        'undistorted_image_max_size': int(config.get('texture_image_resolution', 4096))
+        'undistorted_image_max_size': depthmap_resolution
     }
     
     create_config_for_stage(process_dir, config_yaml)
@@ -51,7 +81,6 @@ def run(process_dir, config):
 
     run_step('undistort', cmd + ['undistort', process_dir], process_dir)
     run_step('compute_depthmaps', cmd + ['compute_depthmaps', process_dir], process_dir)
-    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
     
     crop_dense_point_cloud({'process_dir': process_dir})
     

--- a/backend/app/worker/photogrammetry/utils.py
+++ b/backend/app/worker/photogrammetry/utils.py
@@ -7,7 +7,6 @@ import psutil
 import numpy as np
 import open3d as o3d
 import cv2
-from app.worker.photogrammetry.point_cloud_to_mesh import transform_extent_to_local
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -181,13 +180,15 @@ def get_completed_steps(process_dir: str):
     
     return completed_steps
 
-def run_step(step_name, command, process_dir: str):
+def run_step(step_name, command, process_dir: str, skip_check=False):
     """Run a processing step if it hasn't been completed already"""
-    completed_steps = get_completed_steps(process_dir)
     
-    if step_name in completed_steps:
-        logger.info(f"Skipping already completed step: {step_name}")
-        return True
+    if not skip_check:
+        completed_steps = get_completed_steps(process_dir)
+        
+        if step_name in completed_steps:
+            logger.info(f"Skipping already completed step: {step_name}")
+            return True
         
     logger.info(f"Running step: {step_name}")
     try:
@@ -197,31 +198,3 @@ def run_step(step_name, command, process_dir: str):
         logger.error(f"Step {step_name} failed: {e}")
         return False
 
-def crop_dense_point_cloud(params):
-    """Crop a dense point cloud using geographic bounds"""
-    process_dir = params.get('process_dir')
-
-    reference_lla = None
-    reference_lla_path = os.path.join(process_dir, 'reference_lla.json')
-    with open(reference_lla_path, 'r') as f:
-        reference_lla = json.load(f)
-
-    config = None
-    config_path = os.path.join(process_dir, 'images', 'config.json')
-    if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
-            config = json.load(f)
-
-    bbox = transform_extent_to_local(reference_lla, config)
-
-    if bbox:
-        logger.info("Cropping dense point cloud")
-        dense_ply = os.path.join(process_dir, 'undistorted', 'depthmaps', 'merged.ply')
-        pcd = o3d.io.read_point_cloud(dense_ply)
-        min_bound = np.array([bbox[0], bbox[1], float('-inf')])
-        max_bound = np.array([bbox[2], bbox[3], float('inf')])
-        bbox = o3d.geometry.AxisAlignedBoundingBox(min_bound=min_bound, max_bound=max_bound)
-        cropped_pcd = pcd.crop(bbox)
-        o3d.io.write_point_cloud(dense_ply, cropped_pcd, write_ascii=True, compressed=False, print_progress=True)
-    else:
-        logger.info("Skip point cloud cropping")

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -617,7 +617,8 @@ def create_reconstructed_mesh(pipeline_extended):
         "processes": 1,
         "read_processes": 4,
         "depthmap_processes": 1,
-        'texture_image_resolution': 4096
+        'texture_image_resolution': 4096,
+        'texture_image_processes': 1,
     }
 
     config = {

--- a/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
+++ b/frontend/src/components/Viewer/PhotogrammetryCanvas.tsx
@@ -126,6 +126,7 @@ function PhotogrammetryCanvas({
     read_processes: 4,
     depthmap_processes: 1,
     texture_image_resolution: 4096,
+    texture_image_processes: 1,
     ...pipeline.data,
   })
 
@@ -399,6 +400,20 @@ function PhotogrammetryCanvas({
               defaultValue={data?.texture_image_resolution}
               onChange={(event) =>
                 handleOnChange("texture_image_resolution", parseInt(event.target.value))
+              }
+            />
+          </FormControl>
+          <FormControl mt={2} mb={2} >
+            <FormLabel fontSize="xs" htmlFor="texture_image_processes">
+              Texture image processes
+            </FormLabel>
+            <Input
+              id="texture_image_processes"
+              size="xs"
+              type="number"
+              defaultValue={data?.texture_image_processes}
+              onChange={(event) =>
+                handleOnChange("texture_image_processes", parseInt(event.target.value))
               }
             />
           </FormControl>


### PR DESCRIPTION
This PR includes following:

1. Property texture_image_resolution is independent from the depthmap_resolution. 
2. Undistort phase for dense reconstruction use depthmap_resolution
3. When texture_image_resolution is different from depthmap_resolution  a new set of undistorted images is used only for the texture reconstruction process
4. The .nvm file should is re generated in the texture reconstruction phase as soon the undistorted images are ready

Also Fixes and changes mentioned in this PR : https://github.com/geosolutions-it/digital-twin-toolbox/pull/72

- [X] Include processes options for texture image (texture_image_processes).
- [X] Reviewed sparse to dense process, we should remove texture_image_resolution in undistorted_image_max_size and use depthmap_resolution instead https://github.com/geosolutions-it/digital-twin-toolbox/blob/mesh/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py#L44C55-L44C79