### PR TITLE
Fix #57 export image quality 

### DIFF
--- a/backend/app/worker/photogrammetry/mesh_tiling.py
+++ b/backend/app/worker/photogrammetry/mesh_tiling.py
@@ -140,8 +140,8 @@ def export_gltf(filepath):
     bpy.ops.export_scene.gltf(
         filepath=filepath,
         export_image_format='WEBP',
-        # export_image_quality=export_image_quality,
-        # export_jpeg_quality=export_image_quality,
+        export_image_quality=75,
+        export_jpeg_quality=75,
         
         use_selection=True,
         export_format="GLB",


### PR DESCRIPTION
This PR updates the following properties while we export glb using Blender python api:


```
export_image_quality=75,
export_jpeg_quality=75,
```