### PR TITLE
Fix texture overlapping in the edges 

### DIFF
--- a/backend/app/worker/photogrammetry/mask_images.py
+++ b/backend/app/worker/photogrammetry/mask_images.py
@@ -38,8 +38,9 @@ def run(process_dir):
 
     if config:
         extent = config.get('extent')
+        projection = config.get('projection')
         if extent and len(extent) > 5:
-            local_extent = transform_extent_to_local(reference_lla, config)
+            local_extent = transform_extent_to_local(reference_lla, extent, projection)
             zmin = extent[4]
             zmax = extent[5]
             points = np.array([

--- a/backend/app/worker/photogrammetry/mesh_tiling.py
+++ b/backend/app/worker/photogrammetry/mesh_tiling.py
@@ -205,6 +205,18 @@ def export_gltf(filepath):
         export_nla_strips=False
     )
 
+def export_obj(filepath):
+    bpy.ops.wm.obj_export(
+        filepath=filepath,
+        export_selected_objects=True,
+        export_uv=True,
+        export_normals=True,
+        export_colors=True,
+        export_materials=True,
+        forward_axis='Y', 
+        up_axis='Z'
+    )
+
 def decimate_obj(obj, _faces_target):
     ratio = _faces_target / len(obj.data.polygons)
     logger.info(f"Object faces: {len(obj.data.polygons)}")
@@ -235,6 +247,8 @@ def split_tile(params):
     location_and_rotation = params.get('location_and_rotation')
     transform = params.get('transform')
     tile_size = params.get('tile_size')
+    export_asset = params.get('export_asset')
+    unwrap_uv = params.get('unwrap_uv')
 
     for obj in bpy.context.scene.objects:
         obj.select_set(False)
@@ -282,16 +296,6 @@ def split_tile(params):
     tile.select_set(True)
     bpy.context.view_layer.objects.active = tile
 
-    tile_info = {
-        'center': [
-            center[0],
-            center[1],
-            center_z
-        ],
-        'transform': transform,
-        'size': [tile_size[0], tile_size[1], tile.dimensions[2]]
-    }
-
     merge_vertices()
 
     if len(tile.data.polygons) == 0:
@@ -302,42 +306,53 @@ def split_tile(params):
         decimate_obj(tile, tile_faces_target)
 
     # unwrap the uv
-    try:
-        bpy.ops.object.editmode_toggle()
-        bpy.ops.mesh.select_all(action = 'SELECT')
-        bpy.ops.uv.smart_project()
-        bpy.ops.object.editmode_toggle()
-    except:
-        logger.error(f'Skip: bpy.ops.uv.smart_project failing for {name}')
-        return
+    if unwrap_uv:
+        try:
+            bpy.ops.object.editmode_toggle()
+            bpy.ops.mesh.select_all(action = 'SELECT')
+            bpy.ops.uv.smart_project()
+            bpy.ops.object.editmode_toggle()
+        except:
+            logger.error(f'Skip: bpy.ops.uv.smart_project failing for {name}')
+            return
 
-    bake_img.select = True
-    mat = tile.material_slots[0].material
-    mat.node_tree.nodes.active = bake_img
+    if bake_img and bake_mat:
+        logger.info(f"Baking texture for tile {name}")
+        bake_img.select = True
+        mat = tile.material_slots[0].material
+        mat.node_tree.nodes.active = bake_img
 
-    # bake texture to texture
-    if target_model:
-        target_model.hide_render = False
-        target_model.select_set(True)
-        bpy.context.scene.cycles.bake_type = 'DIFFUSE'
-        bpy.context.scene.render.bake.use_selected_to_active = True
-        bpy.context.scene.render.bake.cage_extrusion = cage_extrusion # (m) to avoid black pixels
-        bpy.ops.object.bake(type='DIFFUSE',use_clear=False)
-        target_model.select_set(False)
-        target_model.hide_render = True
+        # bake texture to texture
+        if target_model:
+            target_model.hide_render = False
+            target_model.select_set(True)
+            bpy.context.scene.cycles.bake_type = 'DIFFUSE'
+            bpy.context.scene.render.bake.use_selected_to_active = True
+            bpy.context.scene.render.bake.cage_extrusion = cage_extrusion # (m) to avoid black pixels
+            bpy.ops.object.bake(type='DIFFUSE',use_clear=False)
+            target_model.select_set(False)
+            target_model.hide_render = True
 
-    # remove all material from tile copy
-    tile.data.materials.clear()
+        # remove all material from tile copy
+        tile.data.materials.clear()
 
-    texture_node = bake_mat.node_tree.nodes.get('TileImageNode')
-    texture_node.image = bake_img.image
-    # apply the bake material
-    tile.data.materials.append(bake_mat)
+        texture_node = bake_mat.node_tree.nodes.get('TileImageNode')
+        texture_node.image = bake_img.image
+        # apply the bake material
+        tile.data.materials.append(bake_mat)
 
     tile.name = name
 
     if apply_transform:
-
+        tile_info = {
+            'center': [
+                center[0],
+                center[1],
+                center_z
+            ],
+            'transform': transform,
+            'size': [tile_size[0], tile_size[1], tile.dimensions[2]]
+        }
         with open(filepath.replace('.glb', '.json'), 'w') as f:
             json.dump(tile_info, f)
 
@@ -349,7 +364,7 @@ def split_tile(params):
         tile.location.y = location[1]
         tile.location.z = location[2]
 
-    export_gltf(filepath)
+    export_asset(filepath)
 
     remove_obj(tile)
     return
@@ -371,6 +386,46 @@ def cut_mesh(left, top, w_unit, h_unit, size):
         
     bmesh.update_edit_mesh(bpy.context.object.data)
     bm.free()
+
+def crop_mesh(input_file,bbox):
+    if not bbox:
+        logger.info("Skip mesh cropping")
+        return
+    
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    clean_up()
+    merged, info = import_mesh(input_file)
+    left = bbox[0] 
+    top = bbox[3] 
+    width = bbox[2] - bbox[0]  # maxx - minx
+    height = bbox[3] - bbox[1]  # maxy - miny
+
+    cut_mesh(left, top, width, height, 1)
+
+    # Back to select mode
+    bpy.ops.object.mode_set(mode='EDIT')
+    bpy.ops.mesh.select_mode(type="VERT")
+    bpy.ops.mesh.select_all(action = 'DESELECT')
+    bpy.ops.object.mode_set(mode='OBJECT')
+
+    split_params = {
+        'bbox': (bbox[0], bbox[1], bbox[2], bbox[3]), 
+        'margin': 0,  
+        'filepath': input_file, 
+        'name': 'clipped_mesh',
+        'target':merged,
+        'should_decimate':False,
+        'apply_transform': False,
+        'export_asset': export_obj,
+        'bake_img': None,
+        'target_model': None,
+        'bake_mat': None,
+        'unwrap_uv': False
+    }
+    split_tile(split_params)
+    remove_obj(merged)
+    clean_up()
+    bpy.ops.wm.read_factory_settings(use_empty=True)
 
 def run(params):
 
@@ -500,6 +555,7 @@ def run(params):
                     'name': tile_name,
                     'bake_img': bake_img,
                     'bake_mat': bake_mat,
+                    'unwrap_uv': True,
                     'target_model': target_model,
                     'tile_faces_target': tile_faces_target,
                     'should_decimate': should_decimate,
@@ -508,7 +564,8 @@ def run(params):
                     'location_and_rotation': location_and_rotation,
                     'transform': transform,
                     'center': [center_x, center_y, 0],
-                    'tile_size': [w_unit, h_unit]
+                    'tile_size': [w_unit, h_unit],
+                    'export_asset': export_gltf
                 })
                 elapsed_time = (time.time() - tile_start_time)
                 logger.info(f"tile {tile_name} completed in {elapsed_time} seconds")

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -13,6 +13,11 @@ from concurrent.futures import ThreadPoolExecutor
 from app.worker.photogrammetry.utils import (
     get_OpenSfM_bin, run_step, create_config_for_stage
 )
+from app.worker.photogrammetry.mesh_tiling import(
+    import_mesh, clean_up
+)
+import bpy
+import bmesh
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -253,12 +258,10 @@ def get_transformation_matrix(reference_lla, projection):
     t_inv = np.linalg.inv(t)
     return [t, t_inv]
 
-def transform_extent_to_local(reference_lla, config):
+def transform_extent_to_local(reference_lla, extent, projection):
 
-    if not config or not reference_lla:
+    if not extent or not reference_lla:
         return None
-    projection = config.get('projection')
-    extent = config.get('extent')
     if not projection or not extent:
         return None
     pyproj_projection = pyproj.Proj(projection)
@@ -495,6 +498,75 @@ def create_texture(params):
     
     logger.info("Created textured")
 
+def crop_textured_mesh(params):
+    """Crop textured mesh based on extent configuration"""
+
+    process_dir = params.get('process_dir')
+
+    reference_lla = None
+    reference_lla_path = os.path.join(process_dir, 'reference_lla.json')
+    with open(reference_lla_path, 'r') as f:
+        reference_lla = json.load(f)
+
+    config = None
+    config_path = os.path.join(process_dir, 'images', 'config.json')
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+
+    extent = config.get('extent_mesh')
+
+    if extent:
+        projection = config.get('projection')
+        bbox = transform_extent_to_local(reference_lla, extent, projection)
+        output_textured_dir = params.get('output_textured_dir')
+        output_textured_dir_zip = params.get('output_textured_dir_zip')
+        input_file = os.path.join(output_textured_dir, 'mesh.obj')
+
+        if not os.path.exists(input_file):
+            logger.warning(f"Mesh file not found at {obj_path}")
+            return
+
+        # Blender part
+        bpy.ops.wm.read_factory_settings(use_empty=True)
+        clean_up()
+        merged, info = import_mesh(input_file)
+        bpy.ops.object.mode_set(mode='EDIT')
+        bm = bmesh.from_edit_mesh(merged.data)
+        verts_to_remove = []
+        for vert in bm.verts:
+            # Get world coordinates
+            world_co = merged.matrix_world @ vert.co
+            
+            # Check if vertex is outside bounding box (X and Y only, ignore Z)
+            if (world_co.x < bbox[0] or world_co.x > bbox[2] or 
+                world_co.y < bbox[1] or world_co.y > bbox[3]):
+                verts_to_remove.append(vert)
+        
+        if verts_to_remove:
+            bmesh.ops.delete(bm, geom=verts_to_remove, context='VERTS')
+        
+        bmesh.update_edit_mesh(merged.data)
+        bpy.ops.object.mode_set(mode='OBJECT')
+        bpy.ops.object.select_all(action='DESELECT')
+        merged.select_set(True)
+        bpy.context.view_layer.objects.active = merged
+        bpy.ops.wm.obj_export(
+            filepath=input_file,
+            export_selected_objects=True,
+            export_uv=True,
+            export_normals=True,
+            export_colors=True,
+            export_materials=True,
+            forward_axis='Y', 
+            up_axis='Z'
+        )
+        if os.path.exists(output_textured_dir_zip):
+            os.remove(output_textured_dir_zip)
+        shutil.make_archive(output_textured_dir.rstrip('/'), 'zip', output_textured_dir)
+        logger.info("Created new textured mesh archive")
+
+
 def run(process_dir, config):
     start = time.time()
     logger.info("Starting mesh generation process")
@@ -529,13 +601,14 @@ def run(process_dir, config):
         'texture_image_resolution': texture_image_resolution,
         'texture_image_processes': texture_image_processes
     }
-
+    logger.info(params)
     if force_delete or not os.path.exists(output_xyz):
         process_point_cloud(params)
     if force_delete or not os.path.exists(output_ply):
         create_mesh(params)
     if force_delete or not os.path.exists(output_textured_dir):
         create_texture(params)
+        crop_textured_mesh(params)
 
     end = time.time()
     elapsed_time = end - start

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -541,7 +541,7 @@ def run(process_dir, config):
     if force_delete or not os.path.exists(output_textured_dir):
         create_texture(params)
     
-        config = None
+    config = None
     config_path = os.path.join(process_dir, 'images', 'config.json')
     if os.path.exists(config_path):
         with open(config_path, 'r') as f:

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -14,10 +14,8 @@ from app.worker.photogrammetry.utils import (
     get_OpenSfM_bin, run_step, create_config_for_stage
 )
 from app.worker.photogrammetry.mesh_tiling import(
-    import_mesh, clean_up
+    crop_mesh
 )
-import bpy
-import bmesh
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -460,7 +458,10 @@ def create_texture(params):
             shutil.rmtree(undistorted_images_dir)
         run_step('undistort', cmd + ['undistort', process_dir], process_dir, skip_check=True)
     
-    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir)
+    visual_sfm_path = os.path.join(process_dir, 'undistorted', 'reconstruction.nvm')
+    if os.path.exists(visual_sfm_path):
+        os.remove(visual_sfm_path)
+    run_step('export_visualsfm', cmd + ['export_visualsfm', process_dir], process_dir, skip_check=True)
     output_textured_dir = params.get('output_textured_dir')
     output_textured_dir_zip = params.get('output_textured_dir_zip')
     output_ply = params.get('output_ply')
@@ -497,75 +498,6 @@ def create_texture(params):
         shutil.make_archive(output_textured_dir, 'zip', output_textured_dir)
     
     logger.info("Created textured")
-
-def crop_textured_mesh(params):
-    """Crop textured mesh based on extent configuration"""
-
-    process_dir = params.get('process_dir')
-
-    reference_lla = None
-    reference_lla_path = os.path.join(process_dir, 'reference_lla.json')
-    with open(reference_lla_path, 'r') as f:
-        reference_lla = json.load(f)
-
-    config = None
-    config_path = os.path.join(process_dir, 'images', 'config.json')
-    if os.path.exists(config_path):
-        with open(config_path, 'r') as f:
-            config = json.load(f)
-
-    extent = config.get('extent_mesh')
-
-    if extent:
-        projection = config.get('projection')
-        bbox = transform_extent_to_local(reference_lla, extent, projection)
-        output_textured_dir = params.get('output_textured_dir')
-        output_textured_dir_zip = params.get('output_textured_dir_zip')
-        input_file = os.path.join(output_textured_dir, 'mesh.obj')
-
-        if not os.path.exists(input_file):
-            logger.warning(f"Mesh file not found at {input_file}")
-            return
-
-        # Blender part
-        bpy.ops.wm.read_factory_settings(use_empty=True)
-        clean_up()
-        merged, info = import_mesh(input_file)
-        bpy.ops.object.mode_set(mode='EDIT')
-        bm = bmesh.from_edit_mesh(merged.data)
-        verts_to_remove = []
-        for vert in bm.verts:
-            # Get world coordinates
-            world_co = merged.matrix_world @ vert.co
-            
-            # Check if vertex is outside bounding box (X and Y only, ignore Z)
-            if (world_co.x < bbox[0] or world_co.x > bbox[2] or 
-                world_co.y < bbox[1] or world_co.y > bbox[3]):
-                verts_to_remove.append(vert)
-        
-        if verts_to_remove:
-            bmesh.ops.delete(bm, geom=verts_to_remove, context='VERTS')
-        
-        bmesh.update_edit_mesh(merged.data)
-        bpy.ops.object.mode_set(mode='OBJECT')
-        bpy.ops.object.select_all(action='DESELECT')
-        merged.select_set(True)
-        bpy.context.view_layer.objects.active = merged
-        bpy.ops.wm.obj_export(
-            filepath=input_file,
-            export_selected_objects=True,
-            export_uv=True,
-            export_normals=True,
-            export_colors=True,
-            export_materials=True,
-            forward_axis='Y', 
-            up_axis='Z'
-        )
-        if os.path.exists(output_textured_dir_zip):
-            os.remove(output_textured_dir_zip)
-        shutil.make_archive(output_textured_dir.rstrip('/'), 'zip', output_textured_dir)
-        logger.info("Created new textured mesh archive")
-
 
 def run(process_dir, config):
     start = time.time()
@@ -608,7 +540,32 @@ def run(process_dir, config):
         create_mesh(params)
     if force_delete or not os.path.exists(output_textured_dir):
         create_texture(params)
-        crop_textured_mesh(params)
+    
+        config = None
+    config_path = os.path.join(process_dir, 'images', 'config.json')
+    if os.path.exists(config_path):
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+    
+    if config.get('extent_mesh'):
+        logger.info("Cropping mesh based on extent configuration")
+        reference_lla = None
+        reference_lla_path = os.path.join(process_dir, 'reference_lla.json')
+        with open(reference_lla_path, 'r') as f:
+            reference_lla = json.load(f)
+        extent = config.get('extent_mesh')
+        projection = config.get('projection')
+        bbox = transform_extent_to_local(reference_lla, extent, projection)
+        input_file = os.path.join(output_textured_dir, 'mesh.obj')
+
+        if os.path.exists(input_file):
+
+            crop_mesh(input_file, bbox)
+
+            if os.path.exists(output_textured_dir_zip):
+                os.remove(output_textured_dir_zip)
+            shutil.make_archive(output_textured_dir.rstrip('/'), 'zip', output_textured_dir)
+            logger.info("Created new textured mesh archive")
 
     end = time.time()
     elapsed_time = end - start

--- a/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
+++ b/backend/app/worker/photogrammetry/point_cloud_to_mesh.py
@@ -524,7 +524,7 @@ def crop_textured_mesh(params):
         input_file = os.path.join(output_textured_dir, 'mesh.obj')
 
         if not os.path.exists(input_file):
-            logger.warning(f"Mesh file not found at {obj_path}")
+            logger.warning(f"Mesh file not found at {input_file}")
             return
 
         # Blender part

--- a/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
+++ b/backend/app/worker/photogrammetry/sparse_reconstruction_to_dense_point_cloud.py
@@ -29,8 +29,9 @@ def crop_dense_point_cloud(params):
     if os.path.exists(config_path):
         with open(config_path, 'r') as f:
             config = json.load(f)
-
-    bbox = transform_extent_to_local(reference_lla, config)
+    extent = config.get('extent')
+    projection = config.get('projection')
+    bbox = transform_extent_to_local(reference_lla, extent, projection)
 
     if bbox:
         logger.info("Cropping dense point cloud")


### PR DESCRIPTION
This PR fixes :

- Currently, some textures are unnecessarily mapped along the edges of the tile or processing area.
- To address this, we can increase the buffer size for each tile until the textured mesh is generated.
- Once the textured mesh is created, we can crop it based on the `extent_mesh` property defined in the initial config.json file.
- Incase` extent_mesh` is not provided , it will not crop.

For an example :: 
```
{
  # 50 meter buffer
    "extent": [
        11.229200965345767,
        43.75821442576263,
        11.236850013592822,
        43.7637582288551,
        0,
        1000
    ],

 # 10 meter buffer
    "extent_mesh": [
        11.229710861147495,
        43.758584026828025,
        11.236340034580108,
        43.76338865493649,
        0,
        1000
    ],
    "projection": "EPSG:7791"
}
```