### PR TITLE
Fix decimation in mesh tiling and improve celery configuration.

### DIFF
--- a/backend/app/worker/main.py
+++ b/backend/app/worker/main.py
@@ -7,10 +7,18 @@ from celery import Celery, Task
 from app.models import Pipeline, Asset
 from celery.states import SUCCESS
 import app.worker.tasks as tasks
+import errno
+from celery.exceptions import Reject
 
 celery = Celery(__name__)
 celery.conf.broker_url = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379")
 celery.conf.result_backend = os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379")
+
+CELERY_VISIBILITY_TIMOUT = int(os.environ.get("CELERY_VISIBILITY_TIMOUT", 3600))
+
+celery.conf.broker_transport_options = {'visibility_timeout': CELERY_VISIBILITY_TIMOUT }
+celery.conf.result_backend_transport_options = {'visibility_timeout': CELERY_VISIBILITY_TIMOUT }
+celery.conf.visibility_timeout = CELERY_VISIBILITY_TIMOUT
 
 class PipelineDatabaseTask(Task):
     abstract = True
@@ -63,9 +71,17 @@ def create_mesh_3dtiles(pipeline_extended):
 def create_point_cloud_3dtiles(pipeline_extended):
     return tasks.create_point_cloud_3dtiles(pipeline_extended)
 
-@celery.task(name="create_reconstructed_mesh", base=PipelineDatabaseTask)
-def create_reconstructed_mesh(pipeline_extended):
-    return tasks.create_reconstructed_mesh(pipeline_extended)
+@celery.task(name="create_reconstructed_mesh", bind=True, base=PipelineDatabaseTask, acks_late=True, max_retries=1)
+def create_reconstructed_mesh(self, pipeline_extended):
+    try:
+        return tasks.create_reconstructed_mesh(pipeline_extended)
+    except MemoryError as exc:
+        raise Reject(exc, requeue=False)
+    except OSError as exc:
+        if exc.errno == errno.ENOMEM:
+            raise Reject(exc, requeue=False)
+    except Exception as exc:
+        raise self.retry(exc, countdown=10)
 
 @celery.task(name="complete_upload_process", base=AssetDatabaseTask)
 def complete_upload_process(options):

--- a/backend/app/worker/photogrammetry/mesh_tiling.py
+++ b/backend/app/worker/photogrammetry/mesh_tiling.py
@@ -251,6 +251,7 @@ def split_tile(params):
     default_mat = params.get('default_mat')
     export_asset = params.get('export_asset')
     unwrap_uv = params.get('unwrap_uv')
+    factor_force_decimation = params.get('factor_force_decimation', 1)
 
     for obj in bpy.context.scene.objects:
         obj.select_set(False)
@@ -307,19 +308,10 @@ def split_tile(params):
     if should_decimate and tile_faces_target and tile_faces_target > 0:
         decimate_obj(tile, tile_faces_target)
         if len(tile.data.polygons) > tile_faces_target:
-            tile.data.materials.clear()
-            export_gltf(filepath)
-            remove_obj(tile)
-            bpy.ops.import_scene.gltf(filepath=filepath)
-            tile = bpy.context.object
-            tile.name = 'tile'
-            tile.hide_render = False
-            bpy.ops.object.select_all(action="DESELECT")
-            tile.select_set(True)
-            bpy.context.view_layer.objects.active = tile
-            decimate_obj(tile, tile_faces_target)
-            tile.data.materials.clear()
-            tile.data.materials.append(default_mat)
+            merge_vertices(factor_force_decimation)
+            if len(tile.data.polygons) > tile_faces_target:
+                decimate_obj(tile, tile_faces_target)
+        merge_vertices()
 
     # unwrap the uv
     if unwrap_uv:
@@ -582,7 +574,8 @@ def run(params):
                     'transform': transform,
                     'center': [center_x, center_y, 0],
                     'tile_size': [w_unit, h_unit],
-                    'export_asset': export_gltf
+                    'export_asset': export_gltf,
+                    'factor_force_decimation': 5 / (2 ** z)
                 })
                 elapsed_time = (time.time() - tile_start_time)
                 logger.info(f"tile {tile_name} completed in {elapsed_time} seconds")

--- a/backend/app/worker/tasks.py
+++ b/backend/app/worker/tasks.py
@@ -597,15 +597,6 @@ def create_reconstructed_mesh(pipeline_extended):
 
     output_paths = setup_output_directory(pipeline_id)
 
-    process_dir = f"{output_paths['output_path']}/process"
-    if not os.path.exists(process_dir):
-        images_dir = f"{process_dir}/images"
-        os.makedirs(images_dir, exist_ok=True)
-        with zipfile.ZipFile(asset_file_path, 'r') as zip_ref:
-            zip_ref.extractall(images_dir)
-        with open(os.path.join(images_dir, "asset_info.txt"), "w") as f:
-            f.write(f"{asset.get('filename')}")
-
     pipeline_config = {}
     if pipeline_extended['data']:
         pipeline_config = pipeline_extended['data']
@@ -629,6 +620,19 @@ def create_reconstructed_mesh(pipeline_extended):
     }
 
     stage = config.get('stage')
+
+    process_dir = f"{output_paths['output_path']}/process"
+
+    if stage == 'all' and config.get('force_delete'):
+        shutil.rmtree(process_dir)
+
+    if not os.path.exists(process_dir):
+        images_dir = f"{process_dir}/images"
+        os.makedirs(images_dir, exist_ok=True)
+        with zipfile.ZipFile(asset_file_path, 'r') as zip_ref:
+            zip_ref.extractall(images_dir)
+        with open(os.path.join(images_dir, "asset_info.txt"), "w") as f:
+            f.write(f"{asset.get('filename')}")
 
     if stage == 'all' or stage == 'images_to_sparse_reconstruction':
         config_overrides = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,13 @@ services:
 
   worker:
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: 10m
+        max-file: "3"
+        labels: "worker_status"
+        env: "os"
     volumes:
       - app-assets-data:/mnt/assets
     image: '${DOCKER_IMAGE_BACKEND?Variable not set}:${TAG-latest}'
@@ -178,6 +185,11 @@ services:
 volumes:
   app-db-data:
   app-assets-data:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /mnt/processing/workspace/assets # /mnt/comunefi_data_output
 
 networks:
   traefik-public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,11 +185,6 @@ services:
 volumes:
   app-db-data:
   app-assets-data:
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: /mnt/processing/workspace/assets # /mnt/comunefi_data_output
 
 networks:
   traefik-public:


### PR DESCRIPTION
This PR adds following:

1.  Revised the decimation of tiles in mesh tiling workflow. 
2.  Additional params in docker compose for improving logging for service worker.
3.  Revised force_delete logic to allow a clean re-run.
4.  Celery configuration to control how long a task can run before the broker assumes the worker failed and retries the task.
